### PR TITLE
Simplify CLI: drop typer/rich, env-only model selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Ape (`ape-linux` on PyPI) is a CLI that turns a natural-language description of a
 Linux task into a shell command using an LLM. The entire implementation lives in a
-single module, `ape_linux.py`, exposing a Typer app as the `ape` console script.
+single module, `ape_linux.py`, exposing two console scripts: `ape` (→ `main()`) and
+`ape-system-info` (→ `system_info()`). It has no CLI framework — argument handling is
+plain `sys.argv`.
 
 **Single-file rule:** all of Ape's implementation must stay in `ape_linux.py` — do
 not split it into additional modules/packages. New behavior is added as functions in
@@ -45,11 +47,12 @@ uv build                      # build the wheel/sdist
 
 The flow in `ape_linux.py` is intentionally minimal:
 
-1. `main()` is the single Typer command. It takes the `query` argument plus
-   `--model/-m`, `--execute/-e`, `--system-info/-s`, and `--version/-v` options.
-   `--system-info` is an eager flag (like `--version`) whose callback prints
-   `detect_system_context()` and exits before the LLM is called, so it works without a
-   `query`.
+1. `main()` is the `ape` entry point. It builds the query by joining `sys.argv[1:]`
+   with spaces, so both `ape "list files"` and `ape list files` work. With no
+   arguments it prints the `HELP` text and exits with code 1. There are no flags —
+   model selection, execution, version, and system-info are all gone. A separate
+   `system_info()` function backs the `ape-system-info` console script; it just prints
+   `detect_system_context()`.
 2. A hard-coded `system_prompt` (with few-shot examples) constrains the model to emit
    **only** a runnable command — no Markdown fences — or `echo "Please try again."`
    for anything off-topic. This prompt is the core product behavior; changes to it
@@ -68,23 +71,21 @@ The flow in `ape_linux.py` is intentionally minimal:
 3. `call_llm()` wraps `pydantic_ai.Agent`, which is the provider abstraction. Models
    are passed through verbatim in `provider:name` form (e.g. `anthropic:claude-sonnet-4-5`),
    so Ape supports any provider Pydantic AI supports without provider-specific code.
-   `--model` defaults to `None`; `main()` resolves the model as `--model` (if given)
-   → `APE_MODEL` env var → the `DEFAULT_MODEL` constant (`openai-chat:gpt-4.1`).
-   Credentials come from each provider's standard env var (e.g. `OPENAI_API_KEY`,
-   `ANTHROPIC_API_KEY`).
-4. Errors are flattened to one-line stderr messages with exit code 1 —
+   The model is resolved solely from the `APE_MODEL` env var → the `DEFAULT_MODEL`
+   constant (`openai-chat:gpt-4.1`); there is no CLI override. Credentials come from
+   each provider's standard env var (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`).
+4. Errors are flattened to one-line stderr messages, raising `SystemExit(1)` —
    `ModelHTTPError` reports status/message; any other exception (bad credentials,
-   unknown provider) prints `str(error)`. Tracebacks are suppressed via
-   `pretty_exceptions_enable=False` on the Typer app.
-5. With `--execute`, the suggested command is run via `subprocess.check_call(..., shell=True)`.
+   unknown provider) prints `str(error)`. There is no CLI framework swallowing
+   tracebacks, so exceptions are caught explicitly.
 
 ## Testing
 
-`tests/test_app.py` uses `typer.testing.CliRunner` and monkeypatches
+`tests/test_app.py` drives `main()` directly via a `run()` helper that monkeypatches
+`sys.argv` and returns the `SystemExit` code (0 on the success path, since `main()`
+doesn't exit then), asserting on captured stdout/stderr with `capsys`. It monkeypatches
 `ape_linux.call_llm` so no real network/LLM calls happen. The `mockenv` fixture sets a
-dummy `OPENAI_API_KEY`. Note `test_app_for_suggestion_with_execute` mocks the LLM to
-return `ls` and actually executes it (harmless, but be aware when adding execute-path
-tests — avoid destructive mocked commands).
+dummy `OPENAI_API_KEY`.
 
 `detect_system_context()` is covered by tests that assert it returns a string without
 crashing, reports the OS, and — importantly — excludes the current username, hostname,

--- a/README.md
+++ b/README.md
@@ -65,32 +65,16 @@ you should get:
 echo "Please try again."
 ```
 
-You can change the model using `--model` or `-m`. Models are specified in
-`provider:name` form.
+You can change the model with the `APE_MODEL` environment variable. Models are
+specified in `provider:name` form.
 See [here](https://ai.pydantic.dev/models/) for the supported providers and models.
 For example:
-
-```bash
-ape "List the contents of the working directory with as much detail as possible" --model anthropic:claude-sonnet-4-5
-```
-
-The model is resolved as follows:
-
-1. If `--model`/`-m` is given, that value is always used.
-2. Otherwise, if the `APE_MODEL` environment variable is set, its value is used.
-3. Otherwise, the default `openai-chat:gpt-4.1` is used.
-
-So you can set a personal default without passing `--model` every time:
 
 ```bash
 export APE_MODEL=anthropic:claude-sonnet-4-5
 ```
 
-Output:
-
-```text
-ls -lha
-```
+If `APE_MODEL` is unset, the default `openai-chat:gpt-4.1` is used.
 
 ## System-aware suggestions
 
@@ -110,11 +94,11 @@ This is all gathered locally with the Python standard library and is best-effort
 anything can't be determined it is simply left out. **No identifying information is
 collected or sent** — never your username, hostname, working directory, or home path.
 
-To see exactly what Ape detects and sends (without calling the model), use
-`--system-info` or `-s`:
+To see exactly what Ape detects and sends (without calling the model), run
+`ape-system-info`:
 
 ```bash
-ape --system-info
+ape-system-info
 ```
 
 Output (example):
@@ -128,27 +112,6 @@ Shell: /bin/zsh
 Privileges: non-root (use sudo for privileged actions)
 Package manager(s): brew
 Available tools: rg, fd, jq, git, curl, docker, tar, rsync, sed, awk
-```
-
-## Executing commands
-
-If you pass `--execute` or `-e`, the tool will run the command for you after printing it! Be careful with this as LLMs often make mistakes:
-
-```bash
-ape "Who am I logged in as?"
-```
-
-Output:
-
-```text
-whoami
-jdoe
-```
-
-For more help:
-
-```bash
-ape --help
 ```
 
 See also: [Gorilla](https://github.com/gorilla-llm)

--- a/ape_linux.py
+++ b/ape_linux.py
@@ -3,32 +3,31 @@
 import os
 import platform
 import shutil
-import subprocess
-from importlib.metadata import version
-from typing import Annotated
+import sys
 
-import rich.console
-import typer
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import ModelHTTPError
 
-__version__ = version("ape_linux")
-
 DEFAULT_MODEL = "openai-chat:gpt-4.1"
 
-app = typer.Typer(add_completion=False, pretty_exceptions_enable=False)
+HELP = """\
+ape — AI for Linux commands.
 
+Usage: ape QUERY
 
-def version_callback(value: bool) -> None:
-    if value:
-        typer.echo(__version__)
-        raise typer.Exit()
+Describe a Linux task in QUERY and ape prints a shell command for it.
 
+Example:
+    ape "Create a symbolic link named 'win' pointing to /mnt/c/Users/jdoe"
+    ln -s /mnt/c/Users/jdoe win
 
-def system_info_callback(value: bool) -> None:
-    if value:
-        typer.echo(detect_system_context())
-        raise typer.Exit()
+The model is read from the APE_MODEL environment variable in provider:name form
+(e.g. anthropic:claude-sonnet-4-5), falling back to {default}. See
+https://ai.pydantic.dev/models/. Credentials come from each provider's standard
+environment variable (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY).
+
+Run `ape-system-info` to print the detected system context sent to the model.\
+""".format(default=DEFAULT_MODEL)
 
 
 def call_llm(model: str, system_prompt: str, user_prompt: str) -> str | None:
@@ -149,64 +148,26 @@ def detect_system_context() -> str:
     return "\n".join(lines)
 
 
-@app.command()
-def main(
-    query: Annotated[
-        str, typer.Argument(help="Query describing a Linux task.", show_default=False)
-    ],
-    model: Annotated[
-        str | None,
-        typer.Option(
-            "--model",
-            "-m",
-            help=(
-                "Model in provider:name form, e.g. anthropic:claude-sonnet-4-5. "
-                "See https://ai.pydantic.dev/models/. If unset, the APE_MODEL "
-                f"env var is used, falling back to {DEFAULT_MODEL}."
-            ),
-        ),
-    ] = None,
-    execute: Annotated[
-        bool,
-        typer.Option(
-            "--execute",
-            "-e",
-            help="Run the command if suggested. Dangerous!",
-        ),
-    ] = False,
-    system_info: Annotated[
-        bool | None,
-        typer.Option(
-            "--system-info",
-            "-s",
-            callback=system_info_callback,
-            help="Show the detected system context sent to the model, then exit.",
-            is_eager=True,
-        ),
-    ] = None,
-    version: Annotated[
-        bool | None,
-        typer.Option(
-            "--version",
-            "-v",
-            callback=version_callback,
-            help="Show the version and exit.",
-            is_eager=True,
-        ),
-    ] = None,
-):
-    """Suggest a command for a Linux task described in QUERY.
+def system_info() -> None:
+    """Entry point for `ape-system-info`: print the detected system context."""
+    print(detect_system_context())
 
-    Example: ape "Create a symbolic link named 'win' pointing to /mnt/c/Users/jdoe"
 
-    Output : ln -s /mnt/c/Users/jdoe win
+def main() -> None:
+    """Entry point for `ape`: suggest a command for the task in the arguments.
+
+    The query is taken from the command-line arguments (``sys.argv``). With no
+    arguments, the help text is printed and the program exits non-zero.
     """
 
-    console = rich.console.Console()
+    args = sys.argv[1:]
+    if not args:
+        print(HELP)
+        raise SystemExit(1)
+    query = " ".join(args)
 
-    # An explicit --model wins. Otherwise fall back to APE_MODEL, then the default.
-    if model is None:
-        model = os.environ.get("APE_MODEL") or DEFAULT_MODEL
+    # The model is read from APE_MODEL, falling back to the default.
+    model = os.environ.get("APE_MODEL") or DEFAULT_MODEL
 
     system_prompt = """\
     You are a Linux command assistant. You will be asked a question about how to
@@ -264,19 +225,16 @@ def main(
     Answer:"""
 
     try:
-        with console.status("[bold][blue]Processing ...", spinner="monkey"):
-            answer = call_llm(model, system_prompt, user_prompt)
+        answer = call_llm(model, system_prompt, user_prompt)
     except ModelHTTPError as error:
-        typer.echo(f"{error.status_code} error: {error.message}", err=True)
-        raise typer.Exit(1)
+        print(f"{error.status_code} error: {error.message}", file=sys.stderr)
+        raise SystemExit(1)
     except Exception as error:
         # Anything else (missing/invalid credentials, unknown provider, etc.)
         # surfaces as a one-line message rather than a traceback.
-        typer.echo(str(error), err=True)
-        raise typer.Exit(1)
+        print(str(error), file=sys.stderr)
+        raise SystemExit(1)
 
     if answer is None:
         answer = 'echo "Please try again."'
-    typer.echo(answer)
-    if execute:
-        subprocess.check_call(answer, shell=True)
+    print(answer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,6 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "pydantic-ai-slim[anthropic,google,groq,mistral,openai]>=1.104.0",
-    "rich>=14.0.0",
-    "typer>=0.15.2",
 ]
 
 [project.urls]
@@ -29,7 +27,8 @@ Homepage = "https://github.com/sbalian/ape"
 Repository = "https://github.com/sbalian/ape"
 
 [project.scripts]
-ape = "ape_linux:app"
+ape = "ape_linux:main"
+ape-system-info = "ape_linux:system_info"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,12 +3,9 @@ import os
 import socket
 
 import pytest
-import typer.testing
 from pydantic_ai.exceptions import ModelHTTPError
 
 import ape_linux
-
-runner = typer.testing.CliRunner()
 
 
 @pytest.fixture
@@ -16,48 +13,76 @@ def mockenv(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "key")
 
 
-def test_app_for_suggestion(mockenv, monkeypatch):
+def run(monkeypatch, argv):
+    """Run ape_linux.main() with the given argv, returning the SystemExit code.
+
+    main() never calls sys.exit() on the success path, so a clean run returns 0.
+    """
+    monkeypatch.setattr("sys.argv", ["ape", *argv])
+    try:
+        ape_linux.main()
+    except SystemExit as exit:
+        return exit.code or 0
+    return 0
+
+
+def test_app_for_suggestion(mockenv, monkeypatch, capsys):
     monkeypatch.setattr("ape_linux.call_llm", lambda *args, **kwargs: "ls")
-    result = runner.invoke(ape_linux.app, ["list all the files"])
-    assert result.stdout == "ls\n"
-    assert result.stderr == ""
-    assert result.exit_code == 0
+    code = run(monkeypatch, ["list all the files"])
+    captured = capsys.readouterr()
+    assert captured.out == "ls\n"
+    assert captured.err == ""
+    assert code == 0
 
 
-def test_app_for_try_again_if_api_returns_none(mockenv, monkeypatch):
+def test_app_joins_multiple_args_into_query(mockenv, monkeypatch, capsys):
+    captured_prompt = {}
+
+    def mockreturn(model, system_prompt, user_prompt):
+        captured_prompt["user"] = user_prompt
+        return "ls"
+
+    monkeypatch.setattr("ape_linux.call_llm", mockreturn)
+    run(monkeypatch, ["list", "all", "the", "files"])
+    assert "list all the files" in captured_prompt["user"]
+
+
+def test_app_prints_help_and_exits_when_no_args(monkeypatch, capsys):
+    code = run(monkeypatch, [])
+    captured = capsys.readouterr()
+    assert "Usage: ape QUERY" in captured.out
+    assert code == 1
+
+
+def test_app_for_try_again_if_api_returns_none(mockenv, monkeypatch, capsys):
     monkeypatch.setattr("ape_linux.call_llm", lambda *args, **kwargs: None)
-    result = runner.invoke(ape_linux.app, ["what is the capital of England?"])
-    assert result.stdout == 'echo "Please try again."\n'
-    assert result.stderr == ""
-    assert result.exit_code == 0
+    code = run(monkeypatch, ["what is the capital of England?"])
+    captured = capsys.readouterr()
+    assert captured.out == 'echo "Please try again."\n'
+    assert captured.err == ""
+    assert code == 0
 
 
-def test_app_with_api_error(mockenv, monkeypatch):
+def test_app_with_api_error(mockenv, monkeypatch, capsys):
     def mockreturn(*args, **kwargs):
         raise ModelHTTPError(
             status_code=500, model_name="openai-chat:gpt-4o", body=None
         )
 
     monkeypatch.setattr("ape_linux.call_llm", mockreturn)
-    result = runner.invoke(ape_linux.app, ["list all the files"])
-    assert result.stdout == ""
-    assert result.exit_code == 1
+    code = run(monkeypatch, ["list all the files"])
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert code == 1
 
 
-def test_app_with_no_api_key(mockenv, monkeypatch):
+def test_app_with_no_api_key(mockenv, monkeypatch, capsys):
     monkeypatch.delenv("OPENAI_API_KEY")
-    result = runner.invoke(ape_linux.app, ["list all the files"])
-    assert result.stdout == ""
-    assert result.stderr != ""
-    assert result.exit_code == 1
-
-
-def test_app_for_suggestion_with_execute(mockenv, monkeypatch):
-    monkeypatch.setattr("ape_linux.call_llm", lambda *args, **kwargs: "ls")
-    result = runner.invoke(ape_linux.app, ["list all the files", "--execute"])
-    assert result.stdout == "ls\n"  # careful, this will actually run
-    assert result.stderr == ""
-    assert result.exit_code == 0
+    code = run(monkeypatch, ["list all the files"])
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err != ""
+    assert code == 1
 
 
 def test_app_uses_default_model_when_unset(mockenv, monkeypatch):
@@ -69,10 +94,10 @@ def test_app_uses_default_model_when_unset(mockenv, monkeypatch):
 
     monkeypatch.delenv("APE_MODEL", raising=False)
     monkeypatch.setattr("ape_linux.call_llm", mockreturn)
-    result = runner.invoke(ape_linux.app, ["list all the files"])
+    code = run(monkeypatch, ["list all the files"])
     assert captured["model"] == ape_linux.DEFAULT_MODEL
     assert ape_linux.DEFAULT_MODEL == "openai-chat:gpt-4.1"
-    assert result.exit_code == 0
+    assert code == 0
 
 
 def test_app_uses_ape_model_env_var(mockenv, monkeypatch):
@@ -84,43 +109,15 @@ def test_app_uses_ape_model_env_var(mockenv, monkeypatch):
 
     monkeypatch.setenv("APE_MODEL", "anthropic:claude-sonnet-4-5")
     monkeypatch.setattr("ape_linux.call_llm", mockreturn)
-    result = runner.invoke(ape_linux.app, ["list all the files"])
+    code = run(monkeypatch, ["list all the files"])
     assert captured["model"] == "anthropic:claude-sonnet-4-5"
-    assert result.exit_code == 0
+    assert code == 0
 
 
-def test_app_model_option_overrides_env_var(mockenv, monkeypatch):
-    captured = {}
-
-    def mockreturn(model, *args, **kwargs):
-        captured["model"] = model
-        return "ls"
-
-    monkeypatch.setenv("APE_MODEL", "anthropic:claude-sonnet-4-5")
-    monkeypatch.setattr("ape_linux.call_llm", mockreturn)
-    result = runner.invoke(
-        ape_linux.app, ["list all the files", "--model", "groq:llama-3.3-70b"]
-    )
-    assert captured["model"] == "groq:llama-3.3-70b"
-    assert result.exit_code == 0
-
-
-def test_app_for_version(mockenv):
-    result = runner.invoke(ape_linux.app, ["--version"])
-    assert result.stdout == f"{ape_linux.__version__}\n"
-    assert result.stderr == ""
-    assert result.exit_code == 0
-
-
-def test_app_system_info_flag(mockenv, monkeypatch):
-    # The flag must print the context and exit without ever calling the LLM.
-    def fail(*args, **kwargs):
-        raise AssertionError("call_llm should not be invoked for --system-info")
-
-    monkeypatch.setattr("ape_linux.call_llm", fail)
-    result = runner.invoke(ape_linux.app, ["--system-info"])
-    assert result.stdout == f"{ape_linux.detect_system_context()}\n"
-    assert result.exit_code == 0
+def test_system_info_entry_point(capsys):
+    ape_linux.system_info()
+    captured = capsys.readouterr()
+    assert captured.out == f"{ape_linux.detect_system_context()}\n"
 
 
 def test_detect_system_context_returns_str_and_never_crashes():

--- a/uv.lock
+++ b/uv.lock
@@ -3,15 +3,6 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -59,8 +50,6 @@ version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-ai-slim", extra = ["anthropic", "google", "groq", "mistral", "openai"] },
-    { name = "rich" },
-    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -71,11 +60,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "groq", "mistral", "openai"], specifier = ">=1.104.0" },
-    { name = "rich", specifier = ">=14.0.0" },
-    { name = "typer", specifier = ">=0.15.2" },
-]
+requires-dist = [{ name = "pydantic-ai-slim", extras = ["anthropic", "google", "groq", "mistral", "openai"], specifier = ">=1.104.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -683,27 +668,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown-it-py"
-version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
 name = "mistralai"
 version = "2.4.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1174,19 +1138,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "15.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1209,15 +1160,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
     { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
     { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -1397,21 +1339,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/e8/20193069d32787f3e1a6ec8940aaa3759d3de8f48f9281bcc0c5cb0939da/ty-0.0.40-py3-none-win32.whl", hash = "sha256:75feb115b3587824c5bdf8f8305e9547b0d1e398e3077b0addc7a1988ea9bb50", size = 10670731, upload-time = "2026-05-27T17:55:31.316Z" },
     { url = "https://files.pythonhosted.org/packages/a3/f9/8b2aa4da61db81322d4a2f9db227afeb48110ca15ae31d380f64c64ceb63/ty-0.0.40-py3-none-win_amd64.whl", hash = "sha256:b0f905edaad788bd61f779a85801b60a267a25ed57fca05aaddd168d9d8896be", size = 11766211, upload-time = "2026-05-27T17:55:51.898Z" },
     { url = "https://files.pythonhosted.org/packages/04/87/369056ed46f1b235130ec0595393262f9cd2061ca3dab276d490980f9343/ty-0.0.40-py3-none-win_arm64.whl", hash = "sha256:07da2b09d9130e2c9a257d2a29beb53105835b0256ee5fdb288fe1aab83fee47", size = 11117369, upload-time = "2026-05-27T17:55:39.329Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.26.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/d3/90c1ee19209cb59f6ad185883fd4ccfcf72f8f0bfd549d5a8b70474611d0/typer-0.26.4.tar.gz", hash = "sha256:25b128964de66c5ea36d5ac82adc579e5e113509b17469edf9f5a4a1864ff2a9", size = 201191, upload-time = "2026-05-30T17:05:04.213Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl", hash = "sha256:11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6", size = 122436, upload-time = "2026-05-30T17:05:05.812Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Replace typer with plain sys.argv handling; print help with no args
- Remove --model, --execute, --version, and --system-info flags
- Resolve model solely from APE_MODEL env var (default openai-chat:gpt-4.1)
- Add separate ape-system-info console script
- Drop rich (no spinner) and typer dependencies