### PR TITLE
Add WSL detection to system context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,11 @@ The flow in `ape_linux.py` is intentionally minimal:
    directly change what the tool outputs. `main()` then appends a system-context block
    (see below) so suggestions match the current machine.
 2a. `detect_system_context()` returns a best-effort, newline-separated `Key: value`
-   block describing the current machine (OS family + macOS/distro version, GNU-vs-BSD
-   userland, CPU arch, `$SHELL`, root-or-not, available package managers, and a probed
-   list of common tools). Two invariants: it **never raises** (every probe is guarded,
+   block describing the current machine (OS family + macOS/distro version, whether the
+   Linux host is WSL, GNU-vs-BSD userland, CPU arch, `$SHELL`, root-or-not, available
+   package managers, and a probed list of common tools). WSL is detected (Linux only)
+   from the `WSL_DISTRO_NAME`/`WSL_INTEROP` env vars or `"microsoft"` in
+   `platform.uname().release`. Two invariants: it **never raises** (every probe is guarded,
    so an unavailable API or missing file just omits that field instead of crashing at
    startup), and it **never includes identifying info** (no username, hostname, working
    directory, or home path). Everything is stdlib (`platform`, `os`, `shutil.which`) and

--- a/ape_linux.py
+++ b/ape_linux.py
@@ -91,6 +91,25 @@ def detect_system_context() -> str:
         if distribution:
             lines.append(f"Distribution: {distribution}")
 
+        # WSL (Windows Subsystem for Linux). WSL2 sets WSL_DISTRO_NAME /
+        # WSL_INTEROP, and both WSL1 and WSL2 ship a kernel whose release
+        # string contains "microsoft" (e.g. 5.15.0-microsoft-standard-WSL2).
+        # platform.uname() never raises. This matters because Windows drives
+        # are mounted under /mnt and interop tools like clip.exe are available.
+        try:
+            release = platform.uname().release
+        except Exception:
+            release = ""
+        if (
+            os.environ.get("WSL_DISTRO_NAME")
+            or os.environ.get("WSL_INTEROP")
+            or "microsoft" in release.lower()
+        ):
+            lines.append(
+                "WSL: yes (Windows Subsystem for Linux; "
+                "Windows drives under /mnt, interop tools like clip.exe available)"
+            )
+
     # CPU architecture (e.g. arm64 vs x86_64) — affects Homebrew prefixes and
     # binary/platform names. Never raises; may be empty.
     machine = platform.machine()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ape-linux"
-version = "0.4.1"
+version = "0.4.2"
 description = "AI for Linux commands"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 import getpass
 import os
+import platform
 import socket
 
 import pytest
@@ -123,6 +124,27 @@ def test_system_info_entry_point(capsys):
 def test_detect_system_context_returns_str_and_never_crashes():
     context = ape_linux.detect_system_context()
     assert isinstance(context, str)
+
+
+def test_detect_system_context_reports_wsl(monkeypatch):
+    # Force the Linux branch and a WSL marker, regardless of the host.
+    monkeypatch.setattr(ape_linux.platform, "system", lambda: "Linux")
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    context = ape_linux.detect_system_context()
+    assert "WSL: yes" in context
+
+
+def test_detect_system_context_omits_wsl_when_absent(monkeypatch):
+    monkeypatch.setattr(ape_linux.platform, "system", lambda: "Linux")
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+    monkeypatch.delenv("WSL_INTEROP", raising=False)
+    monkeypatch.setattr(
+        ape_linux.platform, "uname", lambda: platform.uname_result(
+            "Linux", "host", "5.15.0-generic", "#1", "x86_64"
+        )
+    )
+    context = ape_linux.detect_system_context()
+    assert "WSL:" not in context
 
 
 def test_detect_system_context_reports_operating_system():


### PR DESCRIPTION
Detect Windows Subsystem for Linux (Linux only) via WSL_DISTRO_NAME/ WSL_INTEROP env vars or "microsoft" in platform.uname().release, so the model can tailor suggestions (Windows drives under /mnt, interop tools). Bump version to 0.4.2.